### PR TITLE
Same controller names conflict warning/workaround

### DIFF
--- a/alloyXL.js
+++ b/alloyXL.js
@@ -18,12 +18,18 @@ Alloy.createController = function(name, args) {
 
         // if we have a path, set name to the last part (controller name)
         if (path.length > 0) name = path[path.length - 1];
-
-        // save the controller to Alloy.Controllers for global access
+        
+        // Avoid having issues with same controller name within different folders
         if (Alloy.Controllers[name]) {
-            console.warn("::AlloyXL:: Alloy.Controllers." + name + " exists, and will be overwriten. You might want to name these differently!");
+            if (controller.getView().id) {
+                name = controller.getView().id;
+            } else {
+                console.warn("::AlloyXL:: The controller Alloy.Controllers." + name + " (" + controller.__controllerPath + ") exists, and will be overwriten because it's conflicting with another controller already instanciated with the same name. " +
+                "Please add a unique ID on the top parent view within that controller view so you can use this as the controller name within AlloyXL to avoid this.");
+            }
         }
 
+        // save the controller to Alloy.Controllers for global access
         Alloy.Controllers[name] = controller;
 
         // add a once event handler

--- a/alloyXL.js
+++ b/alloyXL.js
@@ -4,9 +4,6 @@ Alloy.createController = function(name, args) {
     var controller = new(require("alloy/controllers/" + name))(args);
 
     // check if we have a view and not just <Alloy/>
-
-    console.log(name);
-
     if (Object.keys(controller.__views).length > 0) {
         var view = controller.getView();
 
@@ -48,7 +45,7 @@ Alloy.createController = function(name, args) {
                 view.addEventListener("open", open = function(e) {
                     view.removeEventListener("open", open);
                     controller.trigger("open", e);
-                    if (ENV_DEV) console.log("controller " + name + " was opened");
+                    if (ENV_DEV) console.log("::AlloyXL:: controller " + name + " was opened");
                 });
 
                 // fully clean up the view and controller on close
@@ -61,14 +58,14 @@ Alloy.createController = function(name, args) {
                     controller.destroy();
                     controller = null;
 
-                    if (ENV_DEV) console.log("Controller " + name + " cleaned up!");
+                    if (ENV_DEV) console.log("::AlloyXL:: Controller " + name + " cleaned up!");
                 });
 
                 // fire an open event on open
                 view.addEventListener("postlayout", function postlayout(e) {
                     view.removeEventListener("postlayout", postlayout);
                     controller.trigger("postlayout", e);
-                    if (ENV_DEV) console.log("controller " + name + " layout finished");
+                    if (ENV_DEV) console.log("::AlloyXL:: controller " + name + " layout finished");
                 });
 
             } else {
@@ -76,7 +73,7 @@ Alloy.createController = function(name, args) {
                 view.addEventListener("postlayout", function postlayout(e) {
                     view.removeEventListener("postlayout", postlayout);
                     controller.trigger("postlayout", e);
-                    if (ENV_DEV) console.log("controller " + name + " layout finished");
+                    if (ENV_DEV) console.log("::AlloyXL:: controller " + name + " layout finished");
                 });
             }
         }

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # AlloyXL
 
+Better controller management and workflow for [Appcelerator](http://www.appcelerator.com) [Titanium](https://github.com/appcelerator/titanium_mobile) [Alloy MVC framework](https://github.com/appcelerator/alloy).
+
 ## Why?
 
 I build a lot of apps where I use Alloy MVC. In developing apps I end up requiring some additional functionality when it comes to using controllers for example:
@@ -14,7 +16,7 @@ I build a lot of apps where I use Alloy MVC. In developing apps I end up requiri
 So previously I'd end up writing code to clean up a view / controller within say, a close function associated with hitting back or close button, like this:
 
 ```JS
-function doClose(){
+function doClose() {
 	$.getView().close();
 	$.destroy();
 	$.off();

--- a/readme.md
+++ b/readme.md
@@ -36,11 +36,31 @@ The main things I wanted to achieve with AlloyXL were:-
 * Reduce code throughout the app
 * Allow access to controllers globally like Alloy.Collections
 
-## Things to know
+## Same name controllers conflicts
 
-The **Alloy.Controllers** object stores the *last* instance to a controller -- so normally, if you're creating controllers with different names it's all fine -- however if you create two instances to a controller at once, only the *last* one is in **Alloy.Controllers**. 
+The **Alloy.Controllers** object stores the *last* instance to a controller -- so normally, if you're creating controllers with different names it's all fine -- however if you create two instances to a controller at once, only the *last* one is in **Alloy.Controllers**.
+
+If you have two controllers having the same names but located in different folders (`app/controllers/registration/index.js` and `app/controllers/home/index.js` for example), this will cause a conflict within AlloyXL.
+
+However, you can avoid this issue by either using different and unique names for all of your controllers **or** by using a unique ID on the top parent `<NavigationWindow>`, `<Window>` or `<View>` within your controllers and use it as the controller name within AlloyXL:
+
+File: `app/views/registration/index.xml`
+```xml
+<Alloy>
+    <View id="myUniqueID">
+	</View>
+</Alloy>
+```
+
+```javascript
+// Now access the controller using
+Alloy.Controllers.myUniqueID;
+// instead of
+Alloy.Controllers.index;
+```
 
 ## Quick Start
+
 * [Install from NPM the latest version](https://www.npmjs.com/package/alloyxl)
 or
 * [Download the latest version](https://github.com/jasonkneen/AlloyXL) and place in your project (lib folder for Alloy).


### PR DESCRIPTION
Conflicts with two controllers named the same way in different folders.
Better warning message + suggest workaround using a unique ID.
Update `readme.md`.